### PR TITLE
Shipit: multiple analysis, HAWK port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /src/**/elm-stuff/
 /src/**/node_modules/
 /tmp
+.cache
+.elm

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,15 @@ develop-run-shipit_dashboard: develop-run-BACKEND
 develop-run-shipit_frontend: develop-run-FRONTEND
 
 
-
+develop-flask-shell: nix require-APP
+	DEBUG=true \
+	CACHE_TYPE=filesystem \
+	CACHE_DIR=$$PWD/src/$(APP)/cache \
+	DATABASE_URL=sqlite:///$$PWD/app.db \
+  FLASK_APP=$(APP) \
+	APP_SETTINGS=$$PWD/src/$(APP)/settings.py \
+		nix-shell nix/default.nix -A $(APP) \
+    --run "flask shell"
 
 
 

--- a/src/shipit_dashboard/README.md
+++ b/src/shipit_dashboard/README.md
@@ -9,10 +9,19 @@ Add a Bug Analysis to list some bugs:
 
 ```python
 from shipit_dashboard.models import BugAnalysis
-from shipit_dashboard.db import db
+from shipit_dashboard import db
 
-ba = BugAnalysis('demo')
-ba.parameters = "v4=affected&o5=equals&f1=cf_status_firefox50&o3=equals&v3=affected&o1=equals&j2=O    R&resolution=---&resolution=FIXED&f4=cf_status_firefox48&v5=affected&query_format=advanced&f3=cf_statu    s_firefox49&f2=OP&o4=equals&f5=cf_status_firefox47&v1=fixed&f7=CP"
-db.session.add(ba)
-db.session.commit()
+requests = {
+    'aurora' : 'o5=substring&j9=OR&list_id=13189500&o2=substring&f12=CP&o4=substring&known_name=approval-mozilla-aurora&f10=requestees.login_name&f1=OP&o3=substring&f0=OP&f8=OP&v3=approval-mozilla-aurora%3F&columnlist=product%2Ccomponent%2Clast_visit_ts%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate&query_based_on=approval-mozilla-aurora&f9=OP&f4=flagtypes.name&query_format=advanced&o10=substring&j1=OR&f3=flagtypes.name&f2=flagtypes.name&f11=CP&f5=flagtypes.name&f6=CP&f7=CP',
+    'beta' : 'o5=substring&f10=requestees.login_name&f1=OP&j9=OR&o3=substring&list_id=13189499&f0=OP&f8=OP&v3=approval-mozilla-beta%3F&columnlist=product%2Ccomponent%2Clast_visit_ts%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate%2Ccf_tracking_firefox38&query_based_on=approval-mozilla-beta&o2=substring&f9=OP&f4=flagtypes.name&query_format=advanced&o10=substring&f12=CP&j1=OR&f3=flagtypes.name&f2=flagtypes.name&o4=substring&f11=CP&f5=flagtypes.name&f6=CP&f7=CP&known_name=approval-mozilla-beta',
+    'release' : 'o5=substring&j9=OR&list_id=13189498&o2=substring&f12=CP&o4=substring&known_name=approval-mozilla-release&f10=requestees.login_name&f1=OP&o3=substring&f0=OP&f8=OP&v3=approval-mozilla-release%3F&query_based_on=approval-mozilla-release&f9=OP&f4=flagtypes.name&query_format=advanced&o10=substring&j1=OR&f3=flagtypes.name&f2=flagtypes.name&f11=CP&f5=flagtypes.name&f6=CP&f7=CP',
+    'esr45' : 'o5=substring&f10=requestees.login_name&f1=OP&j9=OR&o3=substring&list_id=13189501&f0=OP&f8=OP&v3=approval-mozilla-esr45%3F&query_based_on=approval-esr45&o2=substring&f9=OP&f4=flagtypes.name&query_format=advanced&o10=substring&f12=CP&j1=OR&f3=flagtypes.name&f2=flagtypes.name&o4=substring&f11=CP&f5=flagtypes.name&f6=CP&f7=CP&known_name=approval-esr45',
+}
+
+for name, parameters in requests.items():
+    ba = BugAnalysis(name)
+    ba.parameters = parameters
+    db.db.session.add(ba)
+
+db.db.session.commit()
 ```

--- a/src/shipit_dashboard/bootstrap.sh
+++ b/src/shipit_dashboard/bootstrap.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-RELENG_DIR="$( dirname $DIR)/releng_common"
-
-export DEBUG=true
-export PYTHONPATH="$PYTHONPATH:$DIR:$RELENG_DIR"
-export FLASK_APP=shipit_dashboard
-export DATABASE_URL=sqlite:///$DIR/shipit.db

--- a/src/shipit_dashboard/shipit_dashboard/__init__.py
+++ b/src/shipit_dashboard/shipit_dashboard/__init__.py
@@ -15,7 +15,6 @@ DEBUG = os.environ.get('DEBUG') == 'true' or __name__ == '__main__'
 HERE = os.path.dirname(os.path.abspath(__file__))
 APP_SETTINGS = os.path.abspath(os.path.join(HERE, '..', 'settings.py'))
 
-
 def init_app(app):
 
     # Register extra commands

--- a/src/shipit_dashboard/shipit_dashboard/api.py
+++ b/src/shipit_dashboard/shipit_dashboard/api.py
@@ -34,12 +34,16 @@ def _serialize_bug(bug):
             'comment' : comment['raw_text'],
         }
 
+    status_base_flag = 'cf_status_'
+
     return {
         # Base
         'id': bug.id,
         'bugzilla_id': bug.bugzilla_id,
         'summary' : bug_data['summary'],
         'keywords' : bug_data['keywords'],
+        'flags_status' : dict([(k.replace(status_base_flag, '', 1) ,v) for k,v in bug_data.items() if k.startswith(status_base_flag)]),
+
 
         # Contributor structures
         'creator' : analysis['users']['creator'],

--- a/src/shipit_dashboard/shipit_dashboard/api.py
+++ b/src/shipit_dashboard/shipit_dashboard/api.py
@@ -56,22 +56,30 @@ def _serialize_bug(bug):
         'uplift' : uplift,
     }
 
-def _serialize_analysis(analysis):
+def _serialize_analysis(analysis, full=True):
     """
     Helper to serialize an analysis
     """
-    return {
+    out = {
         'id': analysis.id,
         'name': analysis.name,
-        'bugs': [_serialize_bug(b) for b in analysis.bugs if b.payload],
+        'count' : len(analysis.bugs),
     }
+
+    if full:
+        # Add bugs
+        out['bugs'] = [_serialize_bug(b) for b in analysis.bugs if b.payload]
+    else:
+        out['bugs'] = []
+
+    return out
 
 def list_analysis():
     """
     List all available analysis
     """
     all_analysis = BugAnalysis.query.all()
-    return [_serialize_analysis(analysis) for analysis in all_analysis]
+    return [_serialize_analysis(analysis, False) for analysis in all_analysis]
 
 def get_analysis(analysis_id):
     """

--- a/src/shipit_dashboard/shipit_dashboard/api.py
+++ b/src/shipit_dashboard/shipit_dashboard/api.py
@@ -39,6 +39,7 @@ def _serialize_bug(bug):
         'id': bug.id,
         'bugzilla_id': bug.bugzilla_id,
         'summary' : bug_data['summary'],
+        'keywords' : bug_data['keywords'],
 
         # Contributor structures
         'creator' : analysis['users']['creator'],

--- a/src/shipit_dashboard/shipit_dashboard/swagger.yml
+++ b/src/shipit_dashboard/shipit_dashboard/swagger.yml
@@ -49,11 +49,14 @@ definitions:
     required:
       - id
       - name
+      - count
     properties:
       id:
         type: integer
       name:
         type: string
+      count:
+        type: integer
       bugs:
         type: array
         items:

--- a/src/shipit_dashboard/shipit_dashboard/swagger.yml
+++ b/src/shipit_dashboard/shipit_dashboard/swagger.yml
@@ -69,6 +69,7 @@ definitions:
       - bugzilla_id
       - summary
       - keywords
+      - flags_status
       - changes_size
       - creator
       - assignee
@@ -83,6 +84,10 @@ definitions:
       keywords:
         type: array 
         items:
+          type: string
+      flags_status:
+        type: object
+        additionalProperties:
           type: string
       changes_size:
         type: integer

--- a/src/shipit_dashboard/shipit_dashboard/swagger.yml
+++ b/src/shipit_dashboard/shipit_dashboard/swagger.yml
@@ -65,6 +65,7 @@ definitions:
       - id
       - bugzilla_id
       - summary
+      - keywords
       - changes_size
       - creator
       - assignee
@@ -76,6 +77,10 @@ definitions:
         type: integer 
       summary:
         type: string
+      keywords:
+        type: array 
+        items:
+          type: string
       changes_size:
         type: integer
       creator:

--- a/src/shipit_dashboard/shipit_dashboard/workflow.py
+++ b/src/shipit_dashboard/shipit_dashboard/workflow.py
@@ -2,8 +2,8 @@
 from releng_common.db import db
 from shipit_dashboard.models import BugAnalysis, BugResult
 from shipit_dashboard.helpers import compute_dict_hash
-from clouseau.bugzilla import Bugzilla
-from clouseau.patchanalysis import bug_analysis
+from libmozdata.bugzilla import Bugzilla
+from libmozdata.patchanalysis import bug_analysis
 from sqlalchemy.orm.exc import NoResultFound
 from flask.cli import with_appcontext
 import logging

--- a/src/shipit_frontend/elm-package.json
+++ b/src/shipit_frontend/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.3 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",

--- a/src/shipit_frontend/elm-package.nix
+++ b/src/shipit_frontend/elm-package.nix
@@ -31,6 +31,10 @@
     version = "2.0.1";
     sha256 = "1qafhfzp55z8lzldcxm0ydlp7znp9rj6pcdv6qlvpgm2ds1217xn";
   };
+  "elm-community/json-extra" = {
+    version = "1.0.0";
+    sha256 = "1sanh3qdw91dbdrkbsp3n0wdz6ixaq16842k4ml4f0b59ggf47hy";
+  };
   "evancz/focus" = {
     version = "2.0.1";
     sha256 = "05qm4vx0pxa7s721sjm78kvrk69n4rcbg9vr77ii33jpa28xbkn3";

--- a/src/shipit_frontend/node-packages.nix
+++ b/src/shipit_frontend/node-packages.nix
@@ -3703,13 +3703,13 @@ let
         sha1 = "ce2e1bef835204b4f3099928c602f8b6ae615650";
       };
     };
-    "sshpk-1.9.2" = {
+    "sshpk-1.10.0" = {
       name = "sshpk";
       packageName = "sshpk";
-      version = "1.9.2";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz";
-        sha1 = "3b41351bbad5c34ddf4bd8119937efee31a46765";
+        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz";
+        sha1 = "104d6ba2afb2ac099ab9567c0d193977f29c6dfa";
       };
     };
     "extsprintf-1.0.2" = {
@@ -3809,6 +3809,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
         sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
+      };
+    };
+    "bcrypt-pbkdf-1.0.0" = {
+      name = "bcrypt-pbkdf";
+      packageName = "bcrypt-pbkdf";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz";
+        sha1 = "3ca76b85241c7170bf7d9703e7b9aa74630040d4";
+      };
+    };
+    "tweetnacl-0.14.3" = {
+      name = "tweetnacl";
+      packageName = "tweetnacl";
+      version = "0.14.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz";
+        sha1 = "3da382f670f25ded78d7b3d1792119bca0b7132d";
       };
     };
     "mime-db-1.23.0" = {
@@ -4504,13 +4522,13 @@ let
         sha1 = "afab96262910a7f33c19a5775825c69f34e350ca";
       };
     };
-    "bluebird-3.4.3" = {
+    "bluebird-3.4.5" = {
       name = "bluebird";
       packageName = "bluebird";
-      version = "3.4.3";
+      version = "3.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.3.tgz";
-        sha1 = "1bdf56bb9336f4206f0f4efb7bedd5b5e9392058";
+        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.5.tgz";
+        sha1 = "dfea23c733b7b8e924af97662f9c7bbefefe5ff9";
       };
     };
     "slice-ansi-0.0.4" = {
@@ -7501,13 +7519,13 @@ let
         sha1 = "a0b870729aae214005b7d5032ec2cbbb0fb4451a";
       };
     };
-    "process-0.11.8" = {
+    "process-0.11.9" = {
       name = "process";
       packageName = "process";
-      version = "0.11.8";
+      version = "0.11.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/process/-/process-0.11.8.tgz";
-        sha1 = "58ff3d04ae0641be72c5a6e60ce8f7822d64eb3c";
+        url = "https://registry.npmjs.org/process/-/process-0.11.9.tgz";
+        sha1 = "7bd5ad21aa6253e7da8682264f1e11d11c0318c1";
       };
     };
     "punycode-1.4.1" = {
@@ -10395,7 +10413,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.0"
-      (sources."sshpk-1.9.2" // {
+      (sources."sshpk-1.10.0" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -10418,6 +10436,11 @@ in
       sources."tweetnacl-0.13.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
+      (sources."bcrypt-pbkdf-1.0.0" // {
+        dependencies = [
+          sources."tweetnacl-0.14.3"
+        ];
+      })
       sources."mime-db-1.23.0"
       sources."tr46-0.0.3"
       sources."object-keys-1.0.11"
@@ -10510,7 +10533,7 @@ in
       sources."caller-path-0.1.0"
       sources."resolve-from-1.0.1"
       sources."callsites-0.2.0"
-      sources."bluebird-3.4.3"
+      sources."bluebird-3.4.5"
       sources."slice-ansi-0.0.4"
       sources."tv4-1.2.7"
       sources."xregexp-3.1.1"
@@ -10965,7 +10988,7 @@ in
       sources."https-browserify-0.0.0"
       sources."os-browserify-0.1.2"
       sources."path-browserify-0.0.0"
-      sources."process-0.11.8"
+      sources."process-0.11.9"
       sources."punycode-1.4.1"
       sources."querystring-es3-0.2.1"
       (sources."stream-browserify-1.0.0" // {

--- a/src/shipit_frontend/package.json
+++ b/src/shipit_frontend/package.json
@@ -31,6 +31,7 @@
     "bootstrap": "4.0.0-alpha.2",
     "elm-webpack-loader": "^3.0.3",
     "expose-loader": "0.7.1",
+    "hawk": "^5.1.2",
     "jquery": "2.2.3",
     "mozilla-neo": "1.0.2",
     "tether": "1.3.2",
@@ -38,4 +39,3 @@
   },
   "devDependencies": {}
 }
-

--- a/src/shipit_frontend/src/App.elm
+++ b/src/shipit_frontend/src/App.elm
@@ -33,7 +33,7 @@ type alias Model = {
   release_dashboard : ReleaseDashboard.Model,
   current_page : Page,
   current_user : Maybe User.Model,
-  backend_url: String
+  backend_dashboard_url: String
 }
 
 type Msg
@@ -43,7 +43,7 @@ type Msg
     | SelectAnalysis ReleaseDashboard.Analysis
 
 type alias Flags = {
-    backend_url : String
+    backend_dashboard_url : String
 }
 
 pageLink page attributes =
@@ -104,14 +104,14 @@ location2messages location =
 init : Flags -> (Model, Cmd Msg)
 init flags =
     let
-        (dashboard, newCmd) = ReleaseDashboard.init flags.backend_url
+        (dashboard, newCmd) = ReleaseDashboard.init flags.backend_dashboard_url
     in
     (
       {
          release_dashboard = dashboard,
          current_page = Home,
          current_user = Nothing,
-         backend_url = flags.backend_url
+         backend_dashboard_url = flags.backend_dashboard_url
       },
       Cmd.batch [
         -- Follow through with release dashboard init

--- a/src/shipit_frontend/src/App.elm
+++ b/src/shipit_frontend/src/App.elm
@@ -1,7 +1,7 @@
 port module App exposing (..)
 
 import Dict exposing ( Dict )
-import Html exposing ( Html, div, nav, button, text, a, ul, li, footer, hr )
+import Html exposing ( Html, div, nav, button, text, a, ul, li, footer, hr, span, strong )
 import Html.App
 import Html.Attributes exposing ( attribute, id, class, type', href, target )
 import Html.Events as Events
@@ -10,6 +10,7 @@ import Navigation exposing ( Location )
 import RouteUrl exposing ( UrlChange )
 import RouteUrl.Builder as Builder exposing ( Builder, builder, replacePath )
 import Result exposing ( Result(Ok, Err))
+import RemoteData as RemoteData exposing ( RemoteData(Loading, Success, NotAsked, Failure) )
 
 import App.Home as Home 
 import App.User as User
@@ -28,27 +29,29 @@ type Page
     | ReleaseDashboard
 
 
-type alias Model =
-    { release_dashboard : ReleaseDashboard.Model
-    , current_page : Page
-    , current_user : Maybe User.Model
-    , dashboard_url: String
-    }
+type alias Model = {
+  release_dashboard : ReleaseDashboard.Model,
+  current_page : Page,
+  current_user : Maybe User.Model,
+  backend_url: String
+}
 
 type Msg
     = ShowPage Page
     | UserMsg User.Msg
     | ReleaseDashboardMsg ReleaseDashboard.Msg
+    | SelectAnalysis ReleaseDashboard.Analysis
 
 type alias Flags = {
     user : Maybe User.Model,
-    dashboardUrl : String
+    backend_url : String
 }
-
-
 
 pageLink page attributes =
     eventLink (ShowPage page) attributes
+
+analysisLink analysis attributes =
+    eventLink (SelectAnalysis analysis) attributes
 
 
 delta2url' : Model -> Model -> Maybe Builder
@@ -67,12 +70,6 @@ delta2url : Model -> Model -> Maybe UrlChange
 delta2url previous current =
     Maybe.map Builder.toUrlChange <| delta2url' previous current
 
-
-pages =
-    [ { page = ReleaseDashboard
-      , title = "Release Dashboard"
-      }
-    ]
 
 location2messages' : Builder -> List Msg
 location2messages' builder =
@@ -107,13 +104,18 @@ location2messages location =
 
 init : Flags -> (Model, Cmd Msg)
 init flags =
-    ( {
-         release_dashboard = fst (ReleaseDashboard.init flags.user),
+    let
+        (dashboard, newCmd) = ReleaseDashboard.init flags.user flags.backend_url
+    in
+    (
+      {
+         release_dashboard = dashboard,
          current_page = Home,
          current_user = flags.user,
-         dashboard_url = flags.dashboardUrl
-      }
-    , Cmd.none
+         backend_url = flags.backend_url
+      },
+      -- Follow through with release dashboard init
+      Cmd.map ReleaseDashboardMsg newCmd
     )
 
 
@@ -124,7 +126,7 @@ update msg model =
             case page of
                 ReleaseDashboard ->
                     let 
-                        (dashboard, newCmd) = ReleaseDashboard.init model.current_user
+                        (dashboard, newCmd) = ReleaseDashboard.init model.current_user model.backend_url
                     in
                         (
                             { model | current_page = page, release_dashboard = dashboard },
@@ -132,6 +134,15 @@ update msg model =
                         )
                 _ ->
                     ( { model | current_page = page }, Cmd.none )
+
+        SelectAnalysis analysis ->
+            let
+                (newModel, newCmd) = ReleaseDashboard.update (ReleaseDashboard.SelectAnalysis analysis) model.release_dashboard
+            in
+                (
+                  { model | release_dashboard = newModel, current_page = ReleaseDashboard },
+                  Cmd.map ReleaseDashboardMsg newCmd
+                )
 
         ReleaseDashboardMsg msg' ->
             let
@@ -214,14 +225,41 @@ viewNavBar model =
              [ text "&#9776;" ]
     , pageLink Home [ class "navbar-brand" ]
                     [ text "RelengAPI" ]
-    , div [ class "collapse navbar-toggleable-sm navbar-collapse pull-right" ]
+    , div [ class "collapse navbar-toggleable-sm navbar-collapse navbar-right" ]
           [ ul [ class "nav navbar-nav" ]
-               [ li [ class "nav-item" ]
-                    ( viewDropdown "Pages" ( List.map (\x -> pageLink x.page [ class "dropdown-item" ]
-                                                                                [ text x.title ]) pages ))
-               , li [ class "nav-item" ] ( viewUser model )
-               ]
+              (List.concat [
+                  (viewNavDashboard model.release_dashboard),
+                  [li [ class "nav-item" ] ( viewUser model )]
+              ])
           ]
+    ]
+
+viewNavDashboard: ReleaseDashboard.Model -> List (Html Msg)
+viewNavDashboard dashboard = 
+
+  case dashboard.all_analysis of
+    NotAsked -> [
+      li [class "nav-item text-info"] [text "Initialising ..."]
+    ]
+
+    Loading -> [
+      li [class "nav-item text-info"] [text "Loading ..."]
+    ]
+
+    Failure err -> [
+      li [class "nav-item text-danger"] [text ("Error: " ++ toString err)]
+    ]
+
+    Success allAnalysis -> 
+      (List.map viewNavAnalysis allAnalysis)
+
+viewNavAnalysis: ReleaseDashboard.Analysis -> Html Msg
+viewNavAnalysis analysis =
+    li [class "nav-item"] [
+      analysisLink analysis [class "btn btn-secondary"] [
+        span [] [text (analysis.name ++ " ")],
+        span [class "label label-primary"] [text (toString analysis.count)]
+      ]
     ]
 
 viewFooter =
@@ -237,16 +275,23 @@ viewFooter =
 
 view : Model -> Html Msg
 view model =
-    let
-        log = Debug.log "LOCATION" (builder)
-    in
-    div []
-        [ nav [ id "navbar", class "navbar navbar-full navbar-light" ]
-              [ div [ class "container" ] ( viewNavBar model ) ]
-        , div [ id "content" ]
-              [ div [ class "container-fluid" ] [ viewPage model ] ]
-        , footer [ class "container" ] viewFooter
-        ]
+  div [] [
+    nav [ id "navbar", class "navbar navbar-full navbar-light" ] [
+      div [ class "container" ] ( viewNavBar model )
+    ],
+    div [ id "content" ] [
+      case model.current_user of
+        Just user ->
+          div [class "container-fluid" ] [ viewPage model ]
+        Nothing ->
+          div [class "container"] [
+            div [class "alert alert-warning"] [
+              text "Please login first."
+            ]
+          ]
+    ]
+    , footer [ class "container" ] viewFooter
+  ]
 
 
 subscriptions : Model -> Sub Msg

--- a/src/shipit_frontend/src/App/ReleaseDashboard.elm
+++ b/src/shipit_frontend/src/App/ReleaseDashboard.elm
@@ -58,7 +58,7 @@ type alias Model = {
   current_analysis : WebData (Analysis),
 
   -- Backend base endpoint
-  backend_url : String
+  backend_dashboard_url : String
 }
 
 type Msg
@@ -69,13 +69,13 @@ type Msg
 
 
 init : String -> (Model, Cmd Msg)
-init backend_url =
+init backend_dashboard_url =
   -- Init empty model
   ({
     all_analysis = NotAsked,
     current_analysis = NotAsked,
     current_user = Nothing,
-    backend_url = backend_url
+    backend_dashboard_url = backend_dashboard_url
   }, Cmd.none)
 
 -- Update
@@ -130,7 +130,7 @@ sendRequest model url decoder =
                 ( "Authorization", hawkHeader),
                 ( "Accept", "application/json" )
               ],
-              url = model.backend_url ++ url,
+              url = model.backend_dashboard_url ++ url,
               body = Http.empty
             }
           in

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -6,15 +6,15 @@ require('bootstrap');
 var Hawk = require('hawk');
 require("./index.scss");
 
-var backend_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
-console.info('Dashboard backend used ', backend_url);
+var backend_dashboard_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
+console.info('Dashboard backend used ', backend_dashboard_url);
 
 var storage_key = 'shipit-credentials';
 
 // Start the ELM application
 var url = require('url');
 var app = require('./Main.elm').Main.fullscreen({
-  backend_url: backend_url
+  backend_dashboard_url: backend_dashboard_url
 });
 
 // Local storage ports

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -5,8 +5,8 @@ require('expose?Tether!tether');
 require('bootstrap');
 require("./index.scss");
 
-var dashboardUrl = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
-console.info('Dashboard backend used ', dashboardUrl);
+var backend_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
+console.info('Dashboard backend used ', backend_url);
 
 // Load credentials
 var user = null;
@@ -22,7 +22,7 @@ try {
 var url = require('url');
 var app = require('./Main.elm').Main.fullscreen({
   user: user,
-  dashboardUrl: dashboardUrl
+  backend_url: backend_url
 });
 
 // Local storage ports

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -3,38 +3,55 @@
 require('expose?$!expose?jQuery!jquery');
 require('expose?Tether!tether');
 require('bootstrap');
+var Hawk = require('hawk');
 require("./index.scss");
 
 var backend_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
 console.info('Dashboard backend used ', backend_url);
 
-// Load credentials
-var user = null;
-try {
-  user = JSON.parse(window.localStorage.getItem('shipit-credentials'));
-  user = user.value || user;
-  console.info('Loaded user', user);
-} catch (e) {
-  console.warn('Loading user failed', e);
-}
+var storage_key = 'shipit-credentials';
 
 // Start the ELM application
 var url = require('url');
 var app = require('./Main.elm').Main.fullscreen({
-  user: user,
   backend_url: backend_url
 });
 
 // Local storage ports
+app.ports.localstorage_load.subscribe(function(){
+  // Load credentials from local storage
+  var user = null;
+  try {
+    user = JSON.parse(window.localStorage.getItem(storage_key));
+    user = user.value || user;
+    user.hawkHeader = null;
+    console.info('Loaded user', user);
+  } catch (e) {
+    console.warn('Loading user failed', e);
+  }
+  app.ports.localstorage_get.send(user);
+});
+
 app.ports.localstorage_remove.subscribe(function() {
-  window.localStorage.removeItem('shipit-credentials');
+  window.localStorage.removeItem(storage_key);
   app.ports.localstorage_get.send(null);
 });
 
 app.ports.localstorage_set.subscribe(function(user) {
   user = user ? user.value : null;
-  window.localStorage.setItem('shipit-credentials', JSON.stringify(user));
+  window.localStorage.setItem(storage_key, JSON.stringify(user));
   app.ports.localstorage_get.send(user);
+});
+
+// HAWK auth
+app.ports.hawk_build.subscribe(function(request){
+  var credentials = {
+    id: request.user.clientId,
+    key: request.user.accessToken,
+    algorithm: 'sha256'
+  };
+  var header = Hawk.client.header(request.url, request.method, { credentials: credentials, });
+  app.ports.hawk_get.send(header.field);
 });
 
 app.ports.redirect.subscribe(function(redirect) {


### PR DESCRIPTION
This PR adds several features for the shipit dashboard:
 * Several analysis, with dynamic links in the top bar
 * Load initial localstorage user through the port, not the flags, for a unified Msg integration
 * Uses the hawk Js library to build the HAWK protocol header, and send it to the backend for each request
 * Generic method to send requests towards the backend, always using the hawk header
 * some cosmetic changes (buttons, keywords, ...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/mozilla-releng/48)
<!-- Reviewable:end -->
