### PR TITLE
Shipit: Generic hawk requests

### DIFF
--- a/src/shipit_dashboard/shipit_dashboard/api.py
+++ b/src/shipit_dashboard/shipit_dashboard/api.py
@@ -87,6 +87,7 @@ def list_analysis():
     all_analysis = BugAnalysis.query.all()
     return [_serialize_analysis(analysis, False) for analysis in all_analysis]
 
+@login_required
 def get_analysis(analysis_id):
     """
     Fetch an analysis and all its bugs

--- a/src/shipit_frontend/src/App.elm
+++ b/src/shipit_frontend/src/App.elm
@@ -116,7 +116,7 @@ init flags =
          backend_dashboard_url = flags.backend_dashboard_url
       },
       Cmd.batch [
-        -- Follow through with release dashboard init
+        -- Follow through with sub parts init
         Cmd.map ReleaseDashboardMsg newCmd,
 
         -- Try to load local user
@@ -163,12 +163,13 @@ update msg model =
                 )
 
         HawkMsg hawkMsg ->
-            -- Send msg to Hawk module
+            -- Send msg to Hawk module through RD :/
+            -- TODO: attach Hawk to user ?
             let
-                l = Debug.log "hawk MSG" hawkMsg
-                hawkCmd = Hawk.update hawkMsg
+                l = Debug.log "APP: hawk MSG" hawkMsg
+                (newDashboard, dashboardCmd) = ReleaseDashboard.update (ReleaseDashboard.HawkMsg hawkMsg) model.release_dashboard
             in
-                (model, Cmd.map HawkMsg hawkCmd)
+                ( { model | release_dashboard = newDashboard }, Cmd.map ReleaseDashboardMsg dashboardCmd)
 
 
 viewPage model =

--- a/src/shipit_frontend/src/App.elm
+++ b/src/shipit_frontend/src/App.elm
@@ -14,6 +14,7 @@ import RemoteData as RemoteData exposing ( RemoteData(Loading, Success, NotAsked
 
 import App.Home as Home 
 import App.User as User
+import App.Hawk as Hawk
 import App.ReleaseDashboard as ReleaseDashboard
 import App.Utils exposing ( eventLink )
 
@@ -39,6 +40,7 @@ type alias Model = {
 type Msg
     = ShowPage Page
     | UserMsg User.Msg
+    | HawkMsg Hawk.Msg
     | ReleaseDashboardMsg ReleaseDashboard.Msg
     | SelectAnalysis ReleaseDashboard.Analysis
 
@@ -160,6 +162,13 @@ update msg model =
                   ]
                 )
 
+        HawkMsg hawkMsg ->
+            -- Send msg to Hawk module
+            let
+                l = Debug.log "hawk MSG" hawkMsg
+                hawkCmd = Hawk.update hawkMsg
+            in
+                (model, Cmd.map HawkMsg hawkCmd)
 
 
 viewPage model =
@@ -299,5 +308,5 @@ subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch [ 
       Sub.map UserMsg (User.localstorage_get (User.LoggedIn)),
-      Sub.map UserMsg (User.hawk_get (User.ReceivedHawkHeader)) 
+      Sub.map HawkMsg (Hawk.hawk_get (Hawk.BuiltHeader)) 
     ]

--- a/src/shipit_frontend/src/App/Hawk.elm
+++ b/src/shipit_frontend/src/App/Hawk.elm
@@ -5,6 +5,17 @@ import Json.Decode as Json exposing (Decoder)
 import List exposing ((::))
 import Http
 
+type RequestType = Empty
+  | AllAnalysis
+  | Analysis
+
+type alias Model = {
+  request : Maybe PortRequest,
+  header : Maybe String,
+  response : Maybe Http.Response,
+  task : Maybe (Task Http.RawError Http.Response),
+  requestType : RequestType
+}
 
 type alias PortRequest = {
   -- Simple data for port communication
@@ -16,18 +27,73 @@ type alias PortRequest = {
 }
 
 type Msg
-    = BuiltHeader String
+  = InitRequest User.Model String String RequestType
+  | BuiltHeader String
+  | FetchFailure Http.RawError
+  | FetchSuccess Http.Response
 
-update : Msg -> (Cmd Msg)
-update msg =
-    case msg of
-        BuiltHeader header ->
-            let
-                l = Debug.log "HEADER received" header
-            in
-                Cmd.none
+fromJust : Maybe a -> a
+fromJust x = case x of
+    Just y -> y
+    Nothing -> Debug.crash "error: fromJust Nothing"
 
-sendRequest: PortRequest -> String -> Task Http.RawError Http.Response
+init: (Model, Cmd Msg)
+init =
+  -- Empty model at first
+  ( {
+    request = Nothing,
+    header = Nothing,
+    task = Nothing,
+    response = Nothing,
+    requestType = Empty
+  }, Cmd.none)
+
+
+update : Msg -> Model -> (Model, Cmd Msg)
+update msg model =
+  case msg of
+
+    InitRequest user method url requestType ->
+      -- Start a new request
+      let
+        request = {
+          id = fromJust user.clientId,
+          key = fromJust user.accessToken,
+          certificate = user.certificate,
+          url = url,
+          method = method
+        }
+      in
+        -- Use port to build the header
+        (
+          { model | request = Just request, requestType = requestType },
+          hawk_build request
+        )
+
+    BuiltHeader header ->
+      case model.request of
+        -- Store header and send request
+        Just request ->
+          (
+            { model | header = Just header, task = Just (buildTask request header) },
+            Cmd.none
+            -- sendRequest request header
+          )
+
+        Nothing ->
+          ( model, Cmd.none )
+
+    FetchFailure err ->
+      let
+        l = Debug.log "Fetch failure" err
+      in
+        ( model, Cmd.none )
+
+    FetchSuccess response ->
+      -- Store response
+        ( { model | response = Just response }, Cmd.none )
+
+sendRequest: PortRequest -> String -> Cmd Msg
 sendRequest request header =
   -- Send HTTP request with Hawk header
   Http.send Http.defaultSettings {
@@ -39,46 +105,42 @@ sendRequest request header =
     ],
     body = Http.empty
   }
+  |> Task.perform FetchFailure FetchSuccess
   
 
-fromJust : Maybe a -> a
-fromJust x = case x of
-    Just y -> y
-    Nothing -> Debug.crash "error: fromJust Nothing"
+
+buildTask: PortRequest -> String -> Task Http.RawError Http.Response
+buildTask request header =
+  -- Build Http request task
+  Http.send Http.defaultSettings {
+    url = request.url,
+    verb = request.method,
+    headers = [
+      ( "Authorization", header ),
+      ( "Accept", "application/json" )
+    ],
+    body = Http.empty
+  }
+  
 
 
-buildHeader: PortRequest -> Task never String
-buildHeader request = 
-    let
-      x = hawk_build request
-      l = Debug.log "asked port to build HAWK" x
-    in
-      -- DUMMY
-      (Task.succeed "Hawk DEMOHEADER")
-
-
-workflow: Maybe User.Model -> String -> String -> Decoder obj -> Task Http.Error obj
-workflow maybeUser method url decoder = 
-  case maybeUser of
-    Just user ->
-      let
-        request = {
-          id = fromJust user.clientId,
-          key = fromJust user.accessToken,
-          certificate = user.certificate,
-          url = url,
-          method = method
-        }
-      in
-        -- Build Auth header
-        buildHeader request
-
-        -- Send HTTP request to backend
-        `Task.andThen` \header -> (sendRequest request header) |> (Http.fromJson decoder)
-
-    Nothing ->
-      -- No credentials
-      Task.fail Http.NetworkError
+--workflow: Maybe User.Model -> String -> String -> Decoder obj -> Task Http.Error obj
+--workflow maybeUser method url decoder = 
+--  case maybeUser of
+--    Just user ->
+--      let
+--        request = {
+--        }
+--      in
+--        -- Build Auth header
+--        buildHeader request
+--
+--        -- Send HTTP request to backend
+--        `Task.andThen` \header -> (sendRequest request header) |> (Http.fromJson decoder)
+--
+--    Nothing ->
+--      -- No credentials
+--      Task.fail Http.NetworkError
 
 -- PORTS
 port hawk_get : (String -> msg) -> Sub msg

--- a/src/shipit_frontend/src/App/Hawk.elm
+++ b/src/shipit_frontend/src/App/Hawk.elm
@@ -1,0 +1,85 @@
+port module App.Hawk exposing (..)
+import Task exposing (Task)
+import App.User as User
+import Json.Decode as Json exposing (Decoder)
+import List exposing ((::))
+import Http
+
+
+type alias PortRequest = {
+  -- Simple data for port communication
+  id : String,
+  key : String,
+  certificate : Maybe User.Certificate,
+  url : String,
+  method : String
+}
+
+type Msg
+    = BuiltHeader String
+
+update : Msg -> (Cmd Msg)
+update msg =
+    case msg of
+        BuiltHeader header ->
+            let
+                l = Debug.log "HEADER received" header
+            in
+                Cmd.none
+
+sendRequest: PortRequest -> String -> Task Http.RawError Http.Response
+sendRequest request header =
+  -- Send HTTP request with Hawk header
+  Http.send Http.defaultSettings {
+    url = request.url,
+    verb = request.method,
+    headers = [
+      ( "Authorization", header ),
+      ( "Accept", "application/json" )
+    ],
+    body = Http.empty
+  }
+  
+
+fromJust : Maybe a -> a
+fromJust x = case x of
+    Just y -> y
+    Nothing -> Debug.crash "error: fromJust Nothing"
+
+
+buildHeader: PortRequest -> Task never String
+buildHeader request = 
+    let
+      x = hawk_build request
+      l = Debug.log "asked port to build HAWK" x
+    in
+      -- DUMMY
+      (Task.succeed "Hawk DEMOHEADER")
+
+
+workflow: Maybe User.Model -> String -> String -> Decoder obj -> Task Http.Error obj
+workflow maybeUser method url decoder = 
+  case maybeUser of
+    Just user ->
+      let
+        request = {
+          id = fromJust user.clientId,
+          key = fromJust user.accessToken,
+          certificate = user.certificate,
+          url = url,
+          method = method
+        }
+      in
+        -- Build Auth header
+        buildHeader request
+
+        -- Send HTTP request to backend
+        `Task.andThen` \header -> (sendRequest request header) |> (Http.fromJson decoder)
+
+    Nothing ->
+      -- No credentials
+      Task.fail Http.NetworkError
+
+-- PORTS
+port hawk_get : (String -> msg) -> Sub msg
+port hawk_build : PortRequest -> Cmd msg

--- a/src/shipit_frontend/src/App/User.elm
+++ b/src/shipit_frontend/src/App/User.elm
@@ -1,7 +1,7 @@
 port module App.User exposing (..)
 
 import Dict exposing ( Dict )
-import Json.Decode as JsonDecode exposing ( (:=) )
+import Json.Decode as JsonDecode exposing (Decoder, (:=) )
 import Json.Encode as JsonEncode
 import App.Utils exposing ( eventLink )
 
@@ -17,13 +17,12 @@ type alias Certificate =
     , issuer : String
     }
 
-
 type alias Model =
-    { clientId : Maybe String
-    , accessToken : Maybe String
-    , certificate : Maybe Certificate
-    , hawkHeader : Maybe String
-    }
+  {
+    clientId : Maybe String,
+    accessToken : Maybe String,
+    certificate : Maybe Certificate
+  }
 
 
 type alias LoginUrl =
@@ -37,7 +36,6 @@ type Msg
     | LoggingIn Model
     | LoggedIn (Maybe Model)
     | LocalUser
-    | ReceivedHawkHeader String
     | Logout 
 
 
@@ -55,14 +53,10 @@ update msg model =
         LoggedIn user ->
             case user of
               Just user' ->
-                -- Build hawk header
-                ( user,  hawk_build {
-                  user = user',
-                  method = "GET",
-                  url = "/analysis"
-                })
+                -- Store user
+                ( user,  Cmd.none )
               Nothing ->
-                ( Nothing, Cmd.none)
+                ( Nothing, Cmd.none )
 
         LocalUser ->
             -- Fetch local user from localstorage
@@ -70,14 +64,6 @@ update msg model =
 
         Logout ->
             ( model, localstorage_remove True )
-
-        ReceivedHawkHeader header ->
-            -- Store hawk header
-            case model of
-              Just user ->
-                ( Just { user | hawkHeader = Just header }, Cmd.none )
-              Nothing ->
-                ( Nothing, Cmd.none )
 
 
 decodeCertificate : String -> Result String Certificate
@@ -103,7 +89,6 @@ convertUrlQueryToModel query =
                  Just certificate ->
                      Result.toMaybe <| decodeCertificate certificate
                  Nothing -> Nothing
-    , hawkHeader = Nothing
      }
 
 
@@ -120,14 +105,6 @@ port localstorage_get : (Maybe Model -> msg) -> Sub msg
 port localstorage_load : Bool -> Cmd msg
 port localstorage_remove : Bool -> Cmd msg
 port localstorage_set : LocalStorage -> Cmd msg
-
-type alias HawkRequest = {
-  url : String,
-  method : String,
-  user : Model
-}
-port hawk_get : (String -> msg )-> Sub msg
-port hawk_build : HawkRequest -> Cmd msg
 
 -- XXX: we need to find elm implementation for redirect
 

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -42,12 +42,11 @@ app.ports.localstorage_set.subscribe(function(user) {
 
 // HAWK auth
 app.ports.hawk_build.subscribe(function(request){
-console.info('request', request);
 
   // Build optional cert
   var extData = null;
   if(request.certificate)
-    extData = new Buffer(JSON.stringify({certificate: request.user.certificate})).toString('base64');
+    extData = new Buffer(JSON.stringify({certificate: request.certificate})).toString('base64');
 
   // Build hawk header
   var header = Hawk.client.header(request.url, request.method, {

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -7,7 +7,6 @@ var Hawk = require('hawk');
 require("./index.scss");
 
 var backend_dashboard_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
-//console.info('Dashboard backend used ', backend_dashboard_url);
 
 var storage_key = 'shipit-credentials';
 
@@ -24,10 +23,8 @@ app.ports.localstorage_load.subscribe(function(){
   try {
     user = JSON.parse(window.localStorage.getItem(storage_key));
     user = user.value || user;
-    user.hawkHeader = null;
-    //console.info('Loaded user', user);
   } catch (e) {
-    //console.warn('Loading user failed', e);
+    console.warn('Loading user failed', e);
   }
   app.ports.localstorage_get.send(user);
 });
@@ -45,15 +42,24 @@ app.ports.localstorage_set.subscribe(function(user) {
 
 // HAWK auth
 app.ports.hawk_build.subscribe(function(request){
-  var url = backend_dashboard_url + request.url; // TODO: use direct request.url
-  var header = Hawk.client.header(url, request.method, {
+console.info('request', request);
+
+  // Build optional cert
+  var extData = null;
+  if(request.certificate)
+    extData = new Buffer(JSON.stringify({certificate: request.user.certificate})).toString('base64');
+
+  // Build hawk header
+  var header = Hawk.client.header(request.url, request.method, {
     credentials: {
-      id: request.user.clientId,
-      key: request.user.accessToken,
+      id: request.id,
+      key: request.key,
       algorithm: 'sha256'
     },
-    ext: new Buffer(JSON.stringify({certificate: request.user.certificate})).toString('base64'),
+    ext: extData,
   });
+
+  // Send back header
   app.ports.hawk_get.send(header.field);
 });
 


### PR DESCRIPTION
A new module "Hawk" in the elm code permits to build a new HAWK request every time.
It works with the current implementation of the backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/mozilla-releng/54)
<!-- Reviewable:end -->
